### PR TITLE
Fix animation frame cleanup

### DIFF
--- a/79h.html
+++ b/79h.html
@@ -67,7 +67,7 @@
     var gameDuration = 30; // مدة اللعبة بالثواني
     var timer = gameDuration;
     var moneyItems = [];
-    var gameInterval;
+    var animationFrameId;
     var spawnInterval;
     var countdownInterval;
 
@@ -84,6 +84,7 @@
       score = 0;
       timer = gameDuration;
       moneyItems = [];
+      animationFrameId = null;
       startSpawning();
       startCountdown();
       gameLoop();
@@ -119,7 +120,7 @@
       update();
       draw();
       if(timer > 0) {
-        requestAnimationFrame(gameLoop);
+        animationFrameId = requestAnimationFrame(gameLoop);
       }
     }
 
@@ -177,6 +178,7 @@
     function endGame() {
       clearInterval(spawnInterval);
       clearInterval(countdownInterval);
+      cancelAnimationFrame(animationFrameId);
       canvas.classList.add('hidden');
       gameOverScreen.classList.remove('hidden');
       finalMessage.innerHTML = playerName + "، عيديتك من خالة حصه هي " + score + " ريال";


### PR DESCRIPTION
## Summary
- stop leftover animation frames after the timer ends

## Testing
- `node -c script.js` (syntax check)

------
https://chatgpt.com/codex/tasks/task_e_6848856012ac832896e0421528876e22